### PR TITLE
Include reference to unstable types

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@
 /// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
+/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import manifest from "./fresh.gen.ts";


### PR DESCRIPTION
Include a reference to unstable APIs in `main.ts` to include KV types and avoid errors in VS Code like the one below:

```ts
export const db = await Deno.openKv();
// Error: Property 'openKv' does not exist on type 'typeof Deno'. Did you mean 'open'?
```

